### PR TITLE
Remove OpenCV and Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,7 @@ idna==2.8
 jmespath==0.9.4
 lxml==4.6.3
 numpy==1.18.1
-opencv-python==4.2.0.32
 pandas==1.0.1
-Pillow>=7.1.0
 python-dateutil==2.8.1
 pytz==2019.3
 requests==2.22.0


### PR DESCRIPTION
These dependencies are extremely large, and unused in this project. They should not be considered dependencies.